### PR TITLE
Replace all null task id properties with required = NA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Suggests:
     digest,
     duckdb,
     gh,
+    jsonlite,
     knitr,
     mockery,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # hubData 0.1.0
 
 * Add `collect_hub()` which wraps `dplyr::collect()` and, where possible, converts the output to a `model_out_tbl` class object by default. The function also accepts additional arguments that can be passed to `as_model_out_tbl()`.
+* Allow for parsing `tasks.json` config files where both `required` and `optional` properties of task IDs are set to `null`. This change facilitates the encoding of task IDs in modeling tasks where no value is expected for a given task ID. In model output files, the value in such modeling task task IDs will be `NA`.
 
 # hubData 0.0.1
 

--- a/R/expand_model_out_val_grid.R
+++ b/R/expand_model_out_val_grid.R
@@ -80,7 +80,8 @@ expand_model_out_val_grid <- function(config_tasks,
 
   task_id_l <- purrr::map(
     round_config[["model_tasks"]],
-    ~ .x[["task_ids"]]
+    ~ .x[["task_ids"]] %>%
+      null_taskids_to_na()
   ) %>%
     fix_round_id(
       round_id = round_id,
@@ -242,4 +243,19 @@ pad_missing_cols <- function(x, all_cols) {
     return(cbind(x, missing_cols)[, all_cols])
   }
   x
+}
+
+# Convert required value to NA in task IDs where both required and optional
+#  are  as NA.
+null_taskids_to_na <- function(model_task) {
+  to_na <- purrr::map_lgl(
+    model_task, ~ all(purrr::map_lgl(.x, is.null))
+  )
+  purrr::modify_if(model_task,
+    .p = to_na,
+    ~ list(
+      required = NA,
+      optional = NULL
+    )
+  )
 }

--- a/tests/testthat/_snaps/expand_model_out_val_grid.md
+++ b/tests/testthat/_snaps/expand_model_out_val_grid.md
@@ -110,6 +110,39 @@
       $output_type <string>
       $output_type_id <string>
 
+---
+
+    Code
+      str(expand_model_out_val_grid(jsonlite::fromJSON(test_path("testdata",
+        "configs", "both_null_tasks.json"), simplifyVector = TRUE, simplifyDataFrame = FALSE),
+      round_id = "2023-11-26") %>% dplyr::filter(is.na(horizon)))
+    Output
+      tibble [24 x 7] (S3: tbl_df/tbl/data.frame)
+       $ origin_date   : Date[1:24], format: "2023-11-26" "2023-11-26" ...
+       $ target        : chr [1:24] "peak time hosp" "peak time hosp" "peak time hosp" "peak time hosp" ...
+       $ horizon       : int [1:24] NA NA NA NA NA NA NA NA NA NA ...
+       $ location      : chr [1:24] "US" "01" "02" "US" ...
+       $ age_group     : chr [1:24] "0-130" "0-130" "0-130" "0-0.99" ...
+       $ output_type   : chr [1:24] "cdf" "cdf" "cdf" "cdf" ...
+       $ output_type_id: num [1:24] 1 1 1 1 1 1 1 1 1 1 ...
+
+---
+
+    Code
+      str(expand_model_out_val_grid(jsonlite::fromJSON(test_path("testdata",
+        "configs", "both_null_tasks_swap.json"), simplifyVector = TRUE,
+      simplifyDataFrame = FALSE), round_id = "2023-11-26") %>% dplyr::filter(is.na(
+        horizon)))
+    Output
+      tibble [24 x 7] (S3: tbl_df/tbl/data.frame)
+       $ origin_date   : Date[1:24], format: "2023-11-26" "2023-11-26" ...
+       $ target        : chr [1:24] "peak time hosp" "peak time hosp" "peak time hosp" "peak time hosp" ...
+       $ horizon       : int [1:24] NA NA NA NA NA NA NA NA NA NA ...
+       $ location      : chr [1:24] "US" "01" "02" "US" ...
+       $ age_group     : chr [1:24] "0-130" "0-130" "0-130" "0-0.99" ...
+       $ output_type   : chr [1:24] "cdf" "cdf" "cdf" "cdf" ...
+       $ output_type_id: num [1:24] 1 1 1 1 1 1 1 1 1 1 ...
+
 # expand_model_out_val_grid output controls work correctly
 
     Code
@@ -236,4 +269,18 @@
     Condition
       Error in `checkmate::assert_string()`:
       ! argument "round_id" is missing, with no default
+
+---
+
+    Code
+      str(expand_model_out_val_grid(jsonlite::fromJSON(test_path("testdata",
+        "configs", "both_null_tasks_all.json"), simplifyVector = TRUE,
+      simplifyDataFrame = FALSE), round_id = "2023-11-26") %>% dplyr::filter(is.na(
+        horizon)))
+    Condition
+      Error in `map2()`:
+      i In index: 3.
+      i With name: horizon.
+      Caused by error:
+      ! horizon must be a DataType, not NULL
 

--- a/tests/testthat/test-expand_model_out_val_grid.R
+++ b/tests/testthat/test-expand_model_out_val_grid.R
@@ -69,6 +69,42 @@ test_that("expand_model_out_val_grid works correctly", {
       as_arrow_table = TRUE
     )
   )
+
+  expect_snapshot(
+    str(
+      expand_model_out_val_grid(
+        jsonlite::fromJSON(
+          test_path(
+            "testdata",
+            "configs",
+            "both_null_tasks.json"
+          ),
+          simplifyVector = TRUE,
+          simplifyDataFrame = FALSE
+        ),
+        round_id = "2023-11-26"
+      ) %>%
+        dplyr::filter(is.na(horizon))
+    )
+  )
+
+  expect_snapshot(
+    str(
+      expand_model_out_val_grid(
+        jsonlite::fromJSON(
+          test_path(
+            "testdata",
+            "configs",
+            "both_null_tasks_swap.json"
+          ),
+          simplifyVector = TRUE,
+          simplifyDataFrame = FALSE
+        ),
+        round_id = "2023-11-26"
+      ) %>%
+        dplyr::filter(is.na(horizon))
+    )
+  )
 })
 
 test_that("Setting of round_id value works correctly", {
@@ -195,6 +231,27 @@ test_that("expand_model_out_val_grid errors correctly", {
 
   expect_snapshot(
     expand_model_out_val_grid(config_tasks),
+    error = TRUE
+  )
+
+  # TODO: re-snapshot when error better handled by create_hub_schema
+  # when all horizon properties are null
+  expect_snapshot(
+    str(
+      expand_model_out_val_grid(
+        jsonlite::fromJSON(
+          test_path(
+            "testdata",
+            "configs",
+            "both_null_tasks_all.json"
+          ),
+          simplifyVector = TRUE,
+          simplifyDataFrame = FALSE
+        ),
+        round_id = "2023-11-26"
+      ) %>%
+        dplyr::filter(is.na(horizon))
+    ),
     error = TRUE
   )
 })

--- a/tests/testthat/testdata/configs/both_null_tasks.json
+++ b/tests/testthat/testdata/configs/both_null_tasks.json
@@ -1,0 +1,152 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/tasks-schema.json",
+    "rounds": [
+	{
+            "round_id_from_variable": true,
+            "round_id": "origin_date",
+            "model_tasks": [
+            {
+               	"task_ids": {
+                    "origin_date": {
+                        "required": null,
+                        "optional": [
+                            "2023-11-12", "2023-11-19", "2023-11-26"
+                            ]
+                    },
+                    "target": {
+                        "required": ["inc hosp"],
+                        "optional": null
+                    },
+                    "horizon": {
+                        "required": [1, 2],
+                        "optional": [0]
+                    },
+                    "location": {
+                        "required": null,
+                        "optional": [
+                                "US",
+                                "01",
+                                "02"
+                            ]
+                    },
+                    "age_group":{
+                        "required":["0-130"],
+                        "optional":["0-0.99","1-4","5-17","5-64","18-49","50-64","65-130"]
+		            }
+                },
+                "output_type": {
+                    "quantile":{
+                        "output_type_id":{
+                            "required": [
+                                0.01,
+                                0.025,
+                                0.05,
+                                0.1,
+                                0.15,
+                                0.2,
+                                0.25,
+                                0.3,
+                                0.35,
+                                0.4,
+                                0.45,
+                                0.5,
+                                0.55,
+                                0.6,
+                                0.65,
+                                0.7,
+                                0.75,
+                                0.8,
+                                0.85,
+                                0.9,
+                                0.95,
+                                0.975,
+                                0.99
+                            ],
+                            "optional":null
+                        },
+			            "value":{
+	   		                "type":"double",
+	   		                "minimum":0
+
+			            }
+                    }
+                },
+                "target_metadata": [
+                    {
+                       "target_id": "inc hosp",
+                       "target_name": "Weekly incident RSV hospitalizations",
+                       "target_units": "count",
+                       "target_keys": {
+                           "target": ["inc hosp"]
+                       },
+                       "target_type": "continuous",
+                       "is_step_ahead": true,
+                       "time_unit": "week"
+                    }
+                ]
+		    },
+            {
+                "task_ids": {
+                 "origin_date": {
+                     "required": null,
+                     "optional": [
+                         "2023-11-12", "2023-11-19", "2023-11-26"
+                         ]
+                 },
+                 "target": {
+                     "required": null,
+                     "optional": ["peak time hosp"]
+                 },
+                 "horizon": {
+                     "required": null,
+                     "optional": null
+                 },
+                 "location": {
+                     "required": null,
+                     "optional": [
+                             "US",
+                             "01",
+                             "02"
+                         ]
+                 },
+                 "age_group":{
+                     "required":["0-130"],
+                     "optional":["0-0.99","1-4","5-17","5-64","18-49","50-64","65-130"]
+                 }
+                },
+                "output_type": {
+                    "cdf":{
+                        "output_type_id":{
+                            "required":null,
+                            "optional":[1]
+                        },
+                        "value":{
+                            "type":"double",
+                            "minimum":0,
+                            "maximum":1
+                        }
+                    }
+                },
+                "target_metadata": [
+                 {
+                    "target_id": "peak time hosp",
+                    "target_name": "Peak timing of hospitalization",
+                    "target_units": "population",
+                    "target_keys": {
+                        "target": ["peak time hosp"]
+                    },
+                    "target_type": "discrete",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                 }
+                ]
+            }
+		],
+       	"submissions_due": {
+            "relative_to": "origin_date",
+            "start": -6,
+            "end": 100
+        }
+    }
+    ]
+}

--- a/tests/testthat/testdata/configs/both_null_tasks_all.json
+++ b/tests/testthat/testdata/configs/both_null_tasks_all.json
@@ -1,0 +1,72 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/tasks-schema.json",
+    "rounds": [
+	{
+            "round_id_from_variable": true,
+            "round_id": "origin_date",
+            "model_tasks": [
+            {
+                "task_ids": {
+                 "origin_date": {
+                     "required": null,
+                     "optional": [
+                         "2023-11-12", "2023-11-19", "2023-11-26"
+                         ]
+                 },
+                 "target": {
+                     "required": null,
+                     "optional": ["peak time hosp"]
+                 },
+                 "horizon": {
+                     "required": null,
+                     "optional": null
+                 },
+                 "location": {
+                     "required": null,
+                     "optional": [
+                             "US",
+                             "01",
+                             "02"
+                         ]
+                 },
+                 "age_group":{
+                     "required":["0-130"],
+                     "optional":["0-0.99","1-4","5-17","5-64","18-49","50-64","65-130"]
+                 }
+                },
+                "output_type": {
+                    "cdf":{
+                        "output_type_id":{
+                            "required":null,
+                            "optional":[1]
+                        },
+                        "value":{
+                            "type":"double",
+                            "minimum":0,
+                            "maximum":1
+                        }
+                    }
+                },
+                "target_metadata": [
+                 {
+                    "target_id": "peak time hosp",
+                    "target_name": "Peak timing of hospitalization",
+                    "target_units": "population",
+                    "target_keys": {
+                        "target": ["peak time hosp"]
+                    },
+                    "target_type": "discrete",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                 }
+                ]
+            }
+		],
+       	"submissions_due": {
+            "relative_to": "origin_date",
+            "start": -6,
+            "end": 100
+        }
+    }
+    ]
+}

--- a/tests/testthat/testdata/configs/both_null_tasks_swap.json
+++ b/tests/testthat/testdata/configs/both_null_tasks_swap.json
@@ -1,0 +1,153 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/tasks-schema.json",
+    "rounds": [
+	{
+            "round_id_from_variable": true,
+            "round_id": "origin_date",
+            "model_tasks": [
+            {
+                "task_ids": {
+                 "origin_date": {
+                     "required": null,
+                     "optional": [
+                         "2023-11-12", "2023-11-19", "2023-11-26"
+                         ]
+                 },
+                 "target": {
+                     "required": null,
+                     "optional": ["peak time hosp"]
+                 },
+                 "horizon": {
+                     "required": null,
+                     "optional": null
+                 },
+                 "location": {
+                     "required": null,
+                     "optional": [
+                             "US",
+                             "01",
+                             "02"
+                         ]
+                 },
+                 "age_group":{
+                     "required":["0-130"],
+                     "optional":["0-0.99","1-4","5-17","5-64","18-49","50-64","65-130"]
+                 }
+                },
+                "output_type": {
+                    "cdf":{
+                        "output_type_id":{
+                            "required":null,
+                            "optional":[1]
+                        },
+                        "value":{
+                            "type":"double",
+                            "minimum":0,
+                            "maximum":1
+                        }
+                    }
+                },
+                "target_metadata": [
+                 {
+                    "target_id": "peak time hosp",
+                    "target_name": "Peak timing of hospitalization",
+                    "target_units": "population",
+                    "target_keys": {
+                        "target": ["peak time hosp"]
+                    },
+                    "target_type": "discrete",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                 }
+                ]
+            },
+            {
+               	"task_ids": {
+                    "origin_date": {
+                        "required": null,
+                        "optional": [
+                            "2023-11-12", "2023-11-19", "2023-11-26"
+                            ]
+                    },
+                    "target": {
+                        "required": ["inc hosp"],
+                        "optional": null
+                    },
+                    "horizon": {
+                        "required": [1, 2],
+                        "optional": [0]
+                    },
+                    "location": {
+                        "required": null,
+                        "optional": [
+                                "US",
+                                "01",
+                                "02"
+                            ]
+                    },
+                    "age_group":{
+                        "required":["0-130"],
+                        "optional":["0-0.99","1-4","5-17","5-64","18-49","50-64","65-130"]
+		            }
+                },
+                "output_type": {
+                    "quantile":{
+                        "output_type_id":{
+                            "required": [
+                                0.01,
+                                0.025,
+                                0.05,
+                                0.1,
+                                0.15,
+                                0.2,
+                                0.25,
+                                0.3,
+                                0.35,
+                                0.4,
+                                0.45,
+                                0.5,
+                                0.55,
+                                0.6,
+                                0.65,
+                                0.7,
+                                0.75,
+                                0.8,
+                                0.85,
+                                0.9,
+                                0.95,
+                                0.975,
+                                0.99
+                            ],
+                            "optional":null
+                        },
+			            "value":{
+	   		                "type":"double",
+	   		                "minimum":0
+
+			            }
+                    }
+                },
+                "target_metadata": [
+                    {
+                       "target_id": "inc hosp",
+                       "target_name": "Weekly incident RSV hospitalizations",
+                       "target_units": "count",
+                       "target_keys": {
+                           "target": ["inc hosp"]
+                       },
+                       "target_type": "continuous",
+                       "is_step_ahead": true,
+                       "time_unit": "week"
+                    }
+                ]
+		    }
+
+		],
+       	"submissions_due": {
+            "relative_to": "origin_date",
+            "start": -6,
+            "end": 100
+        }
+    }
+    ]
+}


### PR DESCRIPTION
This PR allows for parsing `tasks.json` config files where both `required` and `optional` properties of task IDs are set to `null`. This change facilitates the encoding of task IDs in modeling tasks where no value is expected for a given task ID. In model output files, the value in such modeling task task IDs will be `NA`.

See https://github.com/Infectious-Disease-Modeling-Hubs/hubAdmin/issues/4 & https://github.com/Infectious-Disease-Modeling-Hubs/hubValidations/issues/75 for further details