### PR TITLE
use dev version of arrow until fixed version v16 released on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,6 +45,7 @@ Suggests:
     testthat (>= 3.2.0)
 Remotes:
     Infectious-Disease-Modeling-Hubs/hubUtils,
+    apache/arrow/r@apache-arrow-15.0.2
 Config/Needs/website: Infectious-Disease-Modeling-Hubs/hubStyle
 Depends: 
     R (>= 2.10)


### PR DESCRIPTION
Related to #15 

Temporary fix to ensure required `arrow` features available when installing `hubData`. Also fixes failing macOS tests. To revert back when `arrow` v16 released on CRAN.